### PR TITLE
Add ToolHive to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Fleur MCP](https://github.com/fleuristes/fleur) - A desktop app marketplace for Claude Desktop.
 - [MCP Agent](https://github.com/lastmile-ai/mcp-agent) - Build effective agents with Model Context Protocol using simple, composable patterns.
 - [ToolRegistry](https://github.com/Oaklight/ToolRegistry) - A PyPI package that simplifies tool integration by streamlining OpenAI client tool calls and managing native Python functions and MCP servers, offering both async and sync interfaces.
+- [ToolHive](https://github.com/StacklokLabs/toolhive) - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization.


### PR DESCRIPTION
ToolHive is a lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security. It provides a curated registry of MCPs with verified configurations, secure secrets management, and standardized packaging using OCI containers.