### PR TITLE
Add MCPs Playground To MCP Clients List

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ All current MCP servers are not in one language. Here is a list from official re
 ### Community
 - [n8n](https://github.com/nerding-io/n8n-nodes-mcp) - interact with Model Context Protocol (MCP) servers in your n8n workflows.
 - [eechat](https://github.com/Lucassssss/eechat) - An open-source, cross-platform desktop application that seamlessly connects with full support for MCP, across Linux, macOS, and Windows.
+- [Mcps-playground](https://mcpsplayground.com/chat) - a playground for Remote MCP servers
 
 ## SDKs
 


### PR DESCRIPTION
**MCP Playground** is a web-based MCP client for testing Claude and Gemini models with Remote MCP server integration.

- **Type:** MCP Client
- **Tech:** Next.js, TypeScript, Cloudflare Workers
- **Features:** Dual AI provider support, OAuth authentication, tool restriction controls
- **URL:** https://mcpsplayground.com/chat
- **Use Case:** Testing MCP servers, comparing AI providers, debugging tool implementations