### PR TITLE
fix: added Clients to TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Model Context Protocol (MCP) is an open protocol published by [Anthropic](ht
 ## Contents
 
 - [Servers](#servers)
+- [Clients](#clients)
 - [SDKs](#sdks)
 - [Tools](#tools)
 


### PR DESCRIPTION
Adds the missing Clients section in the table of contents.

Closes #9