### PR TITLE
Add domain-mcp to Awesome-MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Playwright](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using Playwright.
 - [Node.js](https://github.com/hyperdrive-eng/mcp-nodejs-debugger) - Gives Cursor or Claude Code access to Node.js at runtime to help you debug.
 - [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) - Provides Xcode-related tools for integration with AI assistants and other MCP clients.
+
+- [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) - MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API.
 ### Python
 
 #### Official


### PR DESCRIPTION
This PR adds domain-mcp to the awesome list.

## Entry
```
- [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) - MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API.
```

## Category
Typescript

