### PR TITLE
feat: add mcp benchmarking runner to community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ All current MCP servers are not in one language. Here is a list from official re
 - [ToolHive](https://github.com/StacklokLabs/toolhive) - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization.
 - [Roundtable](https://github.com/askbudi/roundtable) - Zero-configuration MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized interface.
 - [Dify plugin](https://github.com/hjlarry/dify-plugin-mcp_server) - Change a Dify app to a mcp server.
+- [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating MCP server performance and agentic capabilities.


### PR DESCRIPTION
Hi! I've added a benchmarking tool to the Community Tools section. It helps developers evaluate MCP server performance through standardized agent evaluations. Thanks for curating this list!