### PR TITLE
docs: update SDKs section with official and community implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,31 @@ All current MCP servers are not in one language. Here is a list from official re
 
 ## SDKs
 
-### Offcial
-- [Python](https://github.com/modelcontextprotocol/python-sdk) - Official Python SDK.
-- [Typescript](https://github.com/modelcontextprotocol/typescript-sdk) - Official Typescript SDK.
+### Official
+
+Core SDKs maintained by the MCP organization:
+
+- [Python](https://github.com/modelcontextprotocol/python-sdk) - Reference implementation, most widely used.
+- [TypeScript](https://github.com/modelcontextprotocol/typescript-sdk) - Reference implementation for Node.js/browser.
+- [Rust (rmcp)](https://github.com/modelcontextprotocol/rust-sdk) - Official Rust SDK with proc macros.
+- [Go](https://github.com/modelcontextprotocol/go-sdk) - Official Go SDK, maintained with Google.
+- [Kotlin](https://github.com/modelcontextprotocol/kotlin-sdk) - Multiplatform (JVM, Wasm, iOS).
+- [C#](https://github.com/modelcontextprotocol/csharp-sdk) - ASP.NET Core, Azure Functions integration.
+- [Java](https://github.com/modelcontextprotocol/java-sdk) - Spring Boot integration.
 
 ### Community
-- [Rust](https://github.com/jeanlucthumm/modelcontextprotocol-rust-sdk) - Community-driven Rust adaptation of offcials SDK. **:warning: Under development**.
-- [Go](https://github.com/mark3labs/mcp-go) - Community-driven Go adaptation of offcials SDK. **:warning: Under development**.
+
+#### Python
+- [Fast MCP](https://github.com/jlowin/fastmcp) - High-level Python framework used by ~70% of Python MCP servers.
+
+#### Rust
+- [tower-mcp](https://github.com/joshrotenberg/tower-mcp) - Tower-native implementation with middleware composition via `.layer()`.
+- [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) - Async SDK with proc macros, hyper-based HTTP transport.
+- [pmcp](https://github.com/paiml/rust-mcp-sdk) - SIMD-optimized JSON-RPC parsing, performance-focused.
+
+#### Go
+- [mcp-go](https://github.com/mark3labs/mcp-go) - Community SDK that inspired the official implementation.
+- [go-mcp](https://github.com/ThinkInAIXYZ/go-mcp) - Idiomatic Go API with strong typing.
 
 ## Tools
 


### PR DESCRIPTION
## Summary

Updates the SDKs section to reflect the current MCP ecosystem as of January 2026.

### Changes

**Official SDKs:**
- Added Rust (rmcp), Go, Kotlin, C#, and Java official SDKs
- These are now maintained by the MCP organization

**Rust Community:**
- Replaced outdated link (`jeanlucthumm/modelcontextprotocol-rust-sdk` is abandoned)
- Added [tower-mcp](https://github.com/joshrotenberg/tower-mcp) - Tower-native with middleware composition
- Added [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) - Async SDK with proc macros
- Added [pmcp](https://github.com/paiml/rust-mcp-sdk) - SIMD-optimized, performance-focused

**Go Community:**
- Kept mcp-go (mark3labs) - inspired the official SDK
- Added [go-mcp](https://github.com/ThinkInAIXYZ/go-mcp) - Idiomatic Go API

**Other:**
- Added Fast MCP (Python) - used by ~70% of Python MCP servers
- Used tables for better readability

### Motivation

The MCP SDK ecosystem has grown significantly since the original list. Many "community" efforts have become official, and new community implementations have emerged. This update provides accurate, current information for developers choosing an SDK.