### PR TITLE
Add Taskade MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Node.js](https://github.com/hyperdrive-eng/mcp-nodejs-debugger) - Gives Cursor or Claude Code access to Node.js at runtime to help you debug.
 - [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) - Provides Xcode-related tools for integration with AI assistants and other MCP clients.
 - [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) - MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API.
+- [Taskade](https://github.com/taskade/mcp) - Official Taskade MCP server with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media.
 
 ### Python
 


### PR DESCRIPTION
## Add Taskade MCP Server

Adds [Taskade MCP Server](https://github.com/taskade/mcp) to the TypeScript Community servers section.

**Taskade MCP Server** (`@taskade/mcp-server`) is the official MCP server for [Taskade](https://www.taskade.com/) with 62+ tools for managing workspaces, projects, tasks, AI agents, templates, and media. It works with Claude, Cursor, Windsurf, VS Code, and all MCP clients.

- GitHub: https://github.com/taskade/mcp
- npm: `@taskade/mcp-server`
- License: MIT
- Language: TypeScript