### PR TITLE
Add Taskade MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Node.js](https://github.com/hyperdrive-eng/mcp-nodejs-debugger) - Gives Cursor or Claude Code access to Node.js at runtime to help you debug.
 - [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) - Provides Xcode-related tools for integration with AI assistants and other MCP clients.
 - [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) - MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API.
+- [Taskade MCP](https://github.com/taskade/mcp) - Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, and workflow automations. Includes OpenAPI-to-MCP codegen.
 
 ### Python
 


### PR DESCRIPTION
## Summary

- Adds [Taskade MCP](https://github.com/taskade/mcp) to the **Servers > TypeScript > Community** section
- Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, and workflow automations
- Includes OpenAPI-to-MCP codegen
- Install via `npx @taskade/mcp-server`
- npm: [@taskade/mcp-server](https://www.npmjs.com/package/@taskade/mcp-server)
- Website: [taskade.com](https://taskade.com)
- License: MIT
- Language: TypeScript