### PR TITLE
Add Hoofy — Spec-Driven Development MCP Server (Go)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ All current MCP servers are not in one language. Here is a list from official re
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.
 - [Official Github](https://github.com/github/github-mcp-server) - Seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
+- [Hoofy](https://github.com/HendryAvila/Hoofy) - Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline, and greenfield project pipeline with Clarity Gate. 32 MCP tools, single binary, zero dependencies.
 
 ## Clients
 


### PR DESCRIPTION
## Add Hoofy MCP Server

Adds [Hoofy](https://github.com/HendryAvila/Hoofy) to the **Servers > Go** section.

### About Hoofy

Hoofy is an open-source MCP server written in Go that provides:

- **Persistent memory** — SQLite + FTS5 full-text search + knowledge graph with relations between observations
- **Adaptive change pipeline** — 12 flow variants (4 types × 3 sizes) that adapt required stages to the complexity of each change
- **Greenfield project pipeline** — Full spec-driven development workflow with Clarity Gate that blocks advancement until requirements are clear
- **Business rules extraction** — BRG taxonomy + DDD Ubiquitous Language for formal domain modeling
- **32 MCP tools** — Memory management, project pipeline, change pipeline, and ADR capture

### Why it fits the Go section

- Written entirely in Go 1.25
- Single static binary (`CGO_ENABLED=0`), zero runtime dependencies
- MIT License

### Links

- GitHub: https://github.com/HendryAvila/Hoofy
- Install: `go install github.com/HendryAvila/Hoofy/cmd/hoofy@latest`