### PR TITLE
Add mcp-harness to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ All current MCP servers are not in one language. Here is a list from official re
 - [ToolHive](https://github.com/StacklokLabs/toolhive) - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization.
 - [Roundtable](https://github.com/askbudi/roundtable) - Zero-configuration MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized interface.
 - [Dify plugin](https://github.com/hjlarry/dify-plugin-mcp_server) - Change a Dify app to a mcp server.
-- [mcp-harness](https://github.com/gabry-ts/mcp-harness) - In-memory test harness for MCP servers in TypeScript — supertest for MCP.
 - [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating MCP server performance and agentic capabilities.
+- [mcp-harness](https://github.com/gabry-ts/mcp-harness) - In-memory test harness for MCP servers in TypeScript — supertest for MCP.


### PR DESCRIPTION
Adds [mcp-harness](https://github.com/gabry-ts/mcp-harness) to the Tools > Community section.

**mcp-harness** is an in-memory test harness for MCP servers in TypeScript — think supertest for MCP.

- Connects directly to `McpServer` instances via `InMemoryTransport` (no child processes, no IO)
- Also supports subprocess/stdio mode for integration testing
- Framework-agnostic assertion helpers
- Works with Vitest, Jest, node:assert, or any test runner
- Published on npm: [`mcp-harness`](https://www.npmjs.com/package/mcp-harness)