### PR TITLE
Add OpenPaw to Tools > Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Roundtable](https://github.com/askbudi/roundtable) - Zero-configuration MCP server that unifies multiple AI coding assistants (Codex, Claude Code, Cursor, Gemini) through intelligent auto-discovery and standardized interface.
 - [Dify plugin](https://github.com/hjlarry/dify-plugin-mcp_server) - Change a Dify app to a mcp server.
 - [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating MCP server performance and agentic capabilities.
+- [OpenPaw](https://github.com/daxaur/openpaw) - Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills including MCP server setup, Telegram, Discord, Obsidian memory, and more.


### PR DESCRIPTION
Adds [OpenPaw](https://github.com/daxaur/openpaw) to the Tools > Community section.

OpenPaw is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 built-in skills including MCP server setup, Telegram, Discord, Obsidian memory, daily briefings, and more. No daemon, no cloud, MIT licensed.