### PR TITLE
Add defi-mcp to Community Typescript servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Playwright](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using Playwright.
 - [Node.js](https://github.com/hyperdrive-eng/mcp-nodejs-debugger) - Gives Cursor or Claude Code access to Node.js at runtime to help you debug.
 - [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) - Provides Xcode-related tools for integration with AI assistants and other MCP clients.
+- [defi-mcp](https://github.com/OzorOwn/defi-mcp) - DeFi & crypto MCP server with 12 tools: token prices, multi-chain wallet balances, gas estimation, DEX quotes (Jupiter/Uniswap), and token metadata.
 - [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) - MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API.
 - [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers and get structured experimental data from full-text studies. Remote MCP server with free tier.
 - [Taskade MCP](https://github.com/taskade/mcp) - Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, and workflow automations. Includes OpenAPI-to-MCP codegen.


### PR DESCRIPTION
## What

Adds [defi-mcp](https://github.com/OzorOwn/defi-mcp) to the Servers > Community > Typescript section.

## About defi-mcp

A TypeScript MCP server for DeFi and cryptocurrency data with 12 tools covering token prices, multi-chain wallet balances, gas estimation, DEX quotes (Jupiter/Uniswap), and token metadata. Supports Ethereum, Solana, Base, Arbitrum, Polygon, BSC, Optimism, Avalanche, and Fantom.

Works with Claude Desktop, Cursor, and any MCP-compatible client.

**GitHub:** https://github.com/OzorOwn/defi-mcp