### PR TITLE
Add newsmcp — Real-time world news MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers and get structured experimental data from full-text studies. Remote MCP server with free tier.
 - [Taskade MCP](https://github.com/taskade/mcp) - Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, and workflow automations. Includes OpenAPI-to-MCP codegen.
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
+- [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 
 ### Python
 


### PR DESCRIPTION
## Summary

Adds [newsmcp](https://github.com/pranciskus/newsmcp) to the TypeScript Community servers section.

**newsmcp** is a real-time world news MCP server for AI agents. It delivers news events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, and ranked by importance.

- **npm:** [@newsmcp/server](https://www.npmjs.com/package/@newsmcp/server)
- **Website:** [newsmcp.io](https://newsmcp.io)
- **Free to use, no API key required**