### PR TITLE
Add agentic-ads MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) - MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API.
 - [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers and get structured experimental data from full-text studies. Remote MCP server with free tier.
 - [Taskade MCP](https://github.com/taskade/mcp) - Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, and workflow automations. Includes OpenAPI-to-MCP codegen.
+- [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 
 ### Python
 


### PR DESCRIPTION
Adds [agentic-ads](https://github.com/nicofains1/agentic-ads) to the TypeScript community servers list.

**agentic-ads** is an affiliate marketing MCP server that lets AI agents earn USDC commissions from contextual product recommendations. It exposes MCP tools for searching products, creating ad impressions, and tracking clicks.

- TypeScript, 270+ tests
- Live on Railway with persistent DB
- Open source (MIT)