### PR TITLE
Add 402.bot Discovery Oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [AWS Knowledge Base Retrieval](https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval-server) - Retrieve information from the AWS Knowledge Base using the Bedrock Agent Runtime.
 
 #### Community
+- [402.bot Discovery Oracle](https://github.com/sam00101011/402.bot-public) - Discover and inspect live agent APIs through a public read-only remote MCP server with ranked endpoint search, trust inspection, and x402 payment telemetry at `https://api.402.bot/mcp`.
 - [Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) - Deploy, configure & interrogate your resources on the Cloudflare developer platform (e.g. Workers/KV/R2/D1).
 - [Raygun](https://github.com/MindscapeHQ/mcp-server-raygun) - Interact with your crash reporting and real using monitoring data on your Raygun account.
 - [Kagi](https://github.com/ac3xx/mcp-servers-kagi) - A Model Context Protocol server implementation for Kagi's API.


### PR DESCRIPTION
Adds 402.bot Discovery Oracle to the TypeScript community server list.\n\nPublic repo: https://github.com/sam00101011/402.bot-public\nRuntime: https://api.402.bot/mcp\nSetup/docs: https://api.402.bot/mcp/setup\nllms.txt: https://402.bot/llms.txt