### PR TITLE
Add RustChain MCP server (Python, blockchain + video)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [VAP-MCP](https://github.com/elestirelbilinc-sketch/vap-showcase) - MCP server for AI media generation (images, videos, music) with deterministic cost control using reserve-burn-refund billing.
 - [Coupang MCP](https://github.com/uju777/coupang-mcp) - Korean e-commerce (Coupang) product search with Rocket Delivery filtering.
 - [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - Naver Shopping, Cafe, News search for Korean users.
+- [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) - MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing.
 
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.


### PR DESCRIPTION
## Add RustChain MCP Server

Adds [rustchain-mcp](https://github.com/Scottcjn/rustchain-mcp) to the Python Community servers section.

**What it does:**
- MCP server for the RustChain blockchain (RTC token) and BoTTube video platform
- 15 tools + 3 resources for AI agents
- Built with Python, available on PyPI: `pip install rustchain-mcp`
- Mining attestation, wallet management, bounty hunting, video publishing

**Links:**
- GitHub: https://github.com/Scottcjn/rustchain-mcp
- PyPI: https://pypi.org/project/rustchain-mcp/