### PR TITLE
Add preflight MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Taskade MCP](https://github.com/taskade/mcp) - Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, and workflow automations. Includes OpenAPI-to-MCP codegen.
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
+- [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
 
 ### Python
 


### PR DESCRIPTION
Adds [preflight](https://github.com/preflight-dev/preflight) to the Community TypeScript servers section.

Preflight is a 24-tool MCP server for Claude Code that scores prompts before execution across 12 categories, catches ambiguity and missing context, learns from correction patterns, and estimates token cost.

- **npm:** `npx preflight-dev`
- **License:** MIT
- **Language:** TypeScript