### PR TITLE
Add Frihet MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [Frihet](https://github.com/berthelius/frihet-mcp) - AI-native business management with 31 tools for invoicing, expenses, clients, products, quotes, and tax compliance (VeriFactu). Multi-currency, OCR, and Stripe Connect. Supports stdio and remote Streamable HTTP with OAuth 2.0.
 
 ### Python
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
-- [Frihet](https://github.com/berthelius/frihet-mcp) - AI-native business management with 31 tools for invoicing, expenses, clients, products, quotes, and tax compliance (VeriFactu). Multi-currency, OCR, and Stripe Connect. Supports stdio and remote Streamable HTTP with OAuth 2.0.
+- [Frihet](https://github.com/Frihet-io/frihet-mcp) - AI-native business management with 31 tools for invoicing, expenses, clients, products, quotes, and tax compliance (VeriFactu). Multi-currency, OCR, and Stripe Connect. Supports stdio and remote Streamable HTTP with OAuth 2.0.
 
 ### Python
 


### PR DESCRIPTION
## Summary

Adds [Frihet](https://github.com/Frihet-io/frihet-mcp) to the Typescript Community servers section.

**Frihet** (`@frihet/mcp-server`) is an AI-native business management MCP server with 31 tools covering invoicing, expenses, clients, products, quotes, and tax compliance (VeriFactu). Features include multi-currency support (40 currencies), OCR, and Stripe Connect.

- **npm:** https://www.npmjs.com/package/@frihet/mcp-server
- **Transport:** stdio + remote Streamable HTTP (`https://mcp.frihet.io/mcp`)
- **Auth:** OAuth 2.0 + PKCE (remote), API key (stdio)
- **License:** MIT
- **Docs:** https://docs.frihet.io/desarrolladores/mcp-server