### PR TITLE
Add Arch Tools — 61 production-ready AI tools via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [Arch Tools](https://archtools.dev) - 53 production-ready AI tools via MCP with x402 USDC payments. Web scraping, crypto data, AI generation, OCR, and more.
 
 ### Python
 


### PR DESCRIPTION
Adds Arch Tools to the community TypeScript servers section.

**Website:** https://archtools.dev

53 production-ready AI tools accessible via MCP with x402 USDC micropayments.