### PR TITLE
Add AgentRank to Community Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Core SDKs maintained by the MCP organization:
 - [Dify plugin](https://github.com/hjlarry/dify-plugin-mcp_server) - Change a Dify app to a mcp server.
 - [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 - [mcp-harness](https://github.com/gabry-ts/mcp-harness) - In-memory test harness for MCP servers in TypeScript — supertest for MCP.
+- [AgentRank](https://github.com/superlowburn/agentrank) - Live, quality-scored discovery index for 25,000+ MCP servers. Search and find maintained tools via 3 MCP tools (search, lookup, badges). Available as `agentrank-mcp-server` on npm.


### PR DESCRIPTION
Adds [AgentRank](https://github.com/superlowburn/agentrank) to the **Tools > Community** section.

AgentRank is a live, quality-scored discovery index for 25,000+ MCP servers. It scores tools daily using real GitHub signals — freshness, issue health, contributors, dependents, and stars — and exposes three MCP tools for searching and discovering maintained tools at runtime.

- **GitHub:** https://github.com/superlowburn/agentrank
- **npm:** `agentrank-mcp-server`
- **Website:** https://agentrank-ai.com
- **Install:** `npx -y agentrank-mcp-server`

Fits in the Tools > Community section as a discovery/ecosystem utility for MCP.