### PR TITLE
Add wopee-mcp to TypeScript Community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [wopee-mcp](https://www.npmjs.com/package/wopee-mcp) - AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.
 
 ### Python
 


### PR DESCRIPTION
## Summary

Adds [wopee-mcp](https://www.npmjs.com/package/wopee-mcp) to the TypeScript > Community section.

- **npm**: `npx wopee-mcp@latest`
- **What it does**: AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.
- **Language**: TypeScript

## Checklist

- Entry follows existing format (`- [Name](url) - Description.`)
- Placed at the end of the TypeScript Community section, consistent with ordering
- Link points to the npm package page (repo is private)