### PR TITLE
feat: add free-web-search-ultimate to Python Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Coupang MCP](https://github.com/uju777/coupang-mcp) - Korean e-commerce (Coupang) product search with Rocket Delivery filtering.
 - [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - Naver Shopping, Cafe, News search for Korean users.
 - [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) - MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing.
+- [Free Web Search Ultimate](https://github.com/wd041216-bit/free-web-search-ultimate) [![Glama AAA](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate/badges/score.svg)](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate) - Zero-cost, privacy-first universal web search MCP server and CLI tool. Enforces Search-First paradigm. Supports 10+ search engines (DuckDuckGo, Bing, Google, Brave, Wikipedia, Arxiv, YouTube, Reddit). No API key required.
 
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.


### PR DESCRIPTION
## Add free-web-search-ultimate MCP server

Adding [free-web-search-ultimate](https://github.com/wd041216-bit/free-web-search-ultimate) to the Python Community section.

**Key features:**
- Zero-cost, no API key required
- - Privacy-first (DuckDuckGo by default)
- - Supports 10+ search engines (DuckDuckGo, Bing, Google, Brave, Wikipedia, Arxiv, YouTube, Reddit)
- - Also works as CLI tool: `free-web-search`
- - Glama AAA rated [![Glama](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate/badges/score.svg)](https://glama.ai/mcp/servers/wd041216-bit/free-web-search-ultimate)
Install: `pip install free-web-search-ultimate`