### PR TITLE
Add OpenTabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Make](https://github.com/integromat/make-mcp-server) - Turn Make scenarios into callable tools for AI assistants.
 - [VSCode Devtools (Bifrost)](https://github.com/biegehydra/BifrostMCP) - Connect to VSCode IDE and use semantic tools like `find_usages`.
 - [Playwright](https://github.com/microsoft/playwright-mcp) - Provides browser automation capabilities using Playwright.
+- [OpenTabs](https://github.com/opentabs-dev/opentabs) - Plugin-based MCP server that gives AI agents access to web applications through the user's authenticated browser session. Chrome extension with 100+ plugins.
 - [Node.js](https://github.com/hyperdrive-eng/mcp-nodejs-debugger) - Gives Cursor or Claude Code access to Node.js at runtime to help you debug.
 - [XcodeBuildMCP](https://github.com/cameroncooke/XcodeBuildMCP) - Provides Xcode-related tools for integration with AI assistants and other MCP clients.
 - [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) - MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API.


### PR DESCRIPTION
Add [OpenTabs](https://github.com/opentabs-dev/opentabs) to the TypeScript Community Servers section.

**OpenTabs** is a plugin-based MCP server that gives AI agents access to web applications through the user's authenticated browser session. Chrome extension + MCP server with 100+ plugins for Slack, Discord, GitHub, Reddit, Todoist, and more — no API keys required.

- **Website**: https://opentabs.dev
- **GitHub**: https://github.com/opentabs-dev/opentabs
- **npm**: `@opentabs-dev/cli`