### PR TITLE
Add MCP Trust Kit to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Core SDKs maintained by the MCP organization:
 - [Dify plugin](https://github.com/hjlarry/dify-plugin-mcp_server) - Change a Dify app to a mcp server.
 - [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 - [mcp-harness](https://github.com/gabry-ts/mcp-harness) - In-memory test harness for MCP servers in TypeScript — supertest for MCP.
+- [MCP Trust Kit](https://github.com/aak204/MCP-Trust-Kit) - Deterministic CI scanner and surface-risk scoring for MCP servers.


### PR DESCRIPTION
Hi

I'd like to suggest adding **MCP Trust Kit** to your awesome list.

It's an open-source, deterministic CI scanner that evaluates the surface risk (blast radius) of MCP servers before they are deployed to production. It checks for schema hygiene and flags dangerous capabilities (like filesystem mutation or shell execution).

-   Repo: https://github.com/aak204/MCP-Trust-Kit

Thank you for maintaining this valuable resource for the MCP community!