### PR TITLE
Add Toolradar MCP to TypeScript Community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [Toolradar MCP](https://github.com/Nadeus/toolradar-mcp) - Search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, G2/Capterra ratings, and real alternatives.
 
 ### Python
 


### PR DESCRIPTION
Adds [Toolradar MCP](https://github.com/Nadeus/toolradar-mcp) to the TypeScript Community servers section.

**What it does:** Search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, G2/Capterra ratings, and real alternatives.

- **npm:** `toolradar-mcp`
- **Install:** `npx -y toolradar-mcp`
- **Transport:** stdio
- **Free tier:** 100 API calls/day (no key required)
- **Tools:** `search_tools`, `get_tool`, `compare_tools`, `get_alternatives`, `get_pricing`, `list_categories`
- **License:** MIT

Works with Claude Desktop, Cursor, Windsurf, and Claude Code.