### PR TITLE
Add operant-mcp: 51-tool security testing MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
 
 ### Python
 


### PR DESCRIPTION
## New Addition

Adding [operant-mcp](https://github.com/operantlabs/operant-mcp) to the TypeScript community servers section.

**Description:** Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.

**Details:**
- MIT license
- Published on npm: https://www.npmjs.com/package/operant-mcp
- Install: `npx operant-mcp`
- 51 tools covering: SQL injection, XSS, command injection, path traversal, SSRF, PCAP/network forensics, reconnaissance, memory forensics, malware analysis, cloud security, authentication testing, CORS, clickjacking, IDOR, GraphQL security, NoSQL injection, deserialization, and business logic vulnerabilities