### PR TITLE
Add podcast/newsletter/recipe commerce MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [podcast-commerce-mcp](https://github.com/teamsincetoday/podcast-commerce-mcp) - Extract affiliate-ready product mentions from podcast transcripts with brand recognition, confidence scoring, and commerce intelligence. Free tier (200 calls/day), remote on Cloudflare Workers.
+- [newsletter-commerce-mcp](https://github.com/teamsincetoday/newsletter-commerce-mcp) - Extract product recommendations and affiliate marketing opportunities from newsletter and email content. Free tier (200 calls/day), remote on Cloudflare Workers.
+- [recipe-commerce-mcp](https://github.com/teamsincetoday/recipe-commerce-mcp) - Extract ingredients, kitchen tools, and product recommendations from recipe content for affiliate marketing integration. Free tier (200 calls/day), remote on Cloudflare Workers.
 
 ### Python
 


### PR DESCRIPTION
## Summary

Adding 3 remote TypeScript MCP servers for content commerce intelligence — extracting affiliate-ready product data from podcast transcripts, newsletters, and recipes.

### New Servers

- **[podcast-commerce-mcp](https://github.com/teamsincetoday/podcast-commerce-mcp)** — Extract affiliate products from podcast transcripts with NER, brand recognition, and confidence scoring
- **[newsletter-commerce-mcp](https://github.com/teamsincetoday/newsletter-commerce-mcp)** — Extract product recommendations and affiliate marketing opportunities from newsletter content  
- **[recipe-commerce-mcp](https://github.com/teamsincetoday/recipe-commerce-mcp)** — Extract commerce opportunities (ingredients, tools, products) from recipe content

### Why they belong here

- TypeScript, deployed on Cloudflare Workers (remote MCP servers)
- Free tier: 200 calls/day, no API key required
- Paid tier: $0.01/call via x402 micropayments
- Production quality: 643 tests, F1=100%, OWASP compliant
- Fills a gap: content monetization / affiliate marketing is not currently represented in the TypeScript community section