### PR TITLE
Add Nucleus MCP to Python Community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Coupang MCP](https://github.com/uju777/coupang-mcp) - Korean e-commerce (Coupang) product search with Rocket Delivery filtering.
 - [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - Naver Shopping, Cafe, News search for Korean users.
 - [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) - MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing.
+- [Nucleus MCP](https://github.com/eidetic-works/nucleus-mcp) - 114 MCP tools for persistent memory, execution verification, governance, and compliance. Local-first.
 
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.


### PR DESCRIPTION
Adds [Nucleus MCP](https://github.com/eidetic-works/nucleus-mcp) to the Python Community servers section.

- **114 MCP tools** covering persistent memory, execution verification, governance, and compliance
- Local-first architecture — all data stays on the user's machine
- Available via PyPI (`pip install mcp-server-nucleus`) and npm (`npx mcp-server-nucleus`)
- Works with Claude Code, Claude Desktop, Cursor, Windsurf, and other MCP clients