### PR TITLE
Add Helium MCP to Community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [VAP-MCP](https://github.com/elestirelbilinc-sketch/vap-showcase) - MCP server for AI media generation (images, videos, music) with deterministic cost control using reserve-burn-refund billing.
 - [Coupang MCP](https://github.com/uju777/coupang-mcp) - Korean e-commerce (Coupang) product search with Rocket Delivery filtering.
 - [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - Naver Shopping, Cafe, News search for Korean users.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases, ML options pricing, and balanced news synthesis. Remote MCP server with free tier.
 
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the Community Typescript servers section.

Remote MCP server providing:
- Real-time news search with bias scoring across 15+ dimensions (5,000+ sources)
- Live stock, ETF, and crypto data with AI-generated bull/bear cases
- ML-powered options fair value pricing
- Balanced multi-perspective news synthesis
- Semantic meme search

9 tools, free tier (50 queries), no API key required.

Remote server: `https://heliumtrades.com/mcp`

Made with [Cursor](https://cursor.com)