### PR TITLE
Add Not Human Search and AI Dev Jobs MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.
 - [Official Github](https://github.com/github/github-mcp-server) - Seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
 - [Hoofy](https://github.com/HendryAvila/Hoofy) - Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline, and greenfield project pipeline with Clarity Gate. 32 MCP tools, single binary, zero dependencies.
+- [Not Human Search](https://github.com/unitedideas/nothumansearch) - Search engine for AI agent tools and MCP servers. MCP endpoint at nothumansearch.ai/mcp with search, scoring, and live JSON-RPC verification across 1,750+ tools. Listed in the official MCP registry.
+- [AI Dev Jobs](https://github.com/unitedideas/ai-dev-jobs) - AI/ML job board MCP server at aidevboard.com/mcp with search_jobs, get_job, list_companies, and get_stats tools across 6,100+ positions. Listed in the official MCP registry.
 
 ## Clients
 


### PR DESCRIPTION
Add two Go-based MCP servers to the Go community section:

- **Not Human Search** — Search engine for AI agent tools and MCP servers. Indexes 1,750+ tools with `search`, `check_score`, and `verify_mcp` tools via JSON-RPC at nothumansearch.ai/mcp. Listed in the official MCP registry as `ai.nothumansearch/search`.
- **AI Dev Jobs** — AI/ML job board with `search_jobs`, `get_job`, `list_companies`, and `get_stats` MCP tools across 6,100+ positions at aidevboard.com/mcp. Listed in the official MCP registry as `com.aidevboard/jobs`.

Both are production Go services with public GitHub repos.