### PR TITLE
Add EnigmAgent MCP server (Security)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Awesome MCP [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+- [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) — AES-256-GCM + Argon2id encrypted local vault for AI agent credentials. Resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in prompts, logs, or LLM context ☆`1`# Awesome MCP [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 > A curated list of [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) resources.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Official Github](https://github.com/github/github-mcp-server) - Seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
 - [Hoofy](https://github.com/HendryAvila/Hoofy) - Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline, and greenfield project pipeline with Clarity Gate. 32 MCP tools, single binary, zero dependencies.
 
+### Security
+- [EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) (Typescript) - AES-256-GCM + Argon2id encrypted local vault MCP server. Resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in prompts or LLM context.
+
 ## Clients
 
 ### Community


### PR DESCRIPTION
Adds EnigmAgent to a new Security subsection in the Servers list.

**EnigmAgent** — AES-256-GCM + Argon2id encrypted local vault MCP server. Resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in prompts or LLM context.

GitHub: https://github.com/Agnuxo1/EnigmAgent