### PR TITLE
Add KubeStellar Console to Go servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.
 - [Official Github](https://github.com/github/github-mcp-server) - Seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
 - [Hoofy](https://github.com/HendryAvila/Hoofy) - Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline, and greenfield project pipeline with Clarity Gate. 32 MCP tools, single binary, zero dependencies.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with built-in MCP server (kc-agent) for AI-assisted operations across edge and cloud clusters.
 
 ## Clients
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Go servers section.

KubeStellar Console is a CNCF Sandbox project that includes `kc-agent`, a Go-based MCP server bridging AI assistants (Claude, Cursor, VS Code Copilot) to Kubernetes clusters. It provides tools for managing pods, deployments, services, and 20+ CNCF project resources across multiple clusters.

The entry is placed alphabetically in the Go section.