### PR TITLE
Add Rust subsection with Octocode (semantic code indexer + MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Official Github](https://github.com/github/github-mcp-server) - Seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
 - [Hoofy](https://github.com/HendryAvila/Hoofy) - Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline, and greenfield project pipeline with Clarity Gate. 32 MCP tools, single binary, zero dependencies.
 
+### Rust
+- [Muvon/octocode](https://github.com/Muvon/octocode) - Semantic code indexer with GraphRAG knowledge graph and MCP server. Tree-sitter AST parsing, ast-grep structural search, code signatures view. 13+ languages. Local-first, Apache 2.0.
+
+
 ## Clients
 
 ### Community


### PR DESCRIPTION
Adding a new **Rust** subsection under `## Servers` (consistent with the existing TypeScript/Python/Go pattern) and listing **Muvon/octocode** as the first entry.

**Why a Rust section?** The list already has a Rust subsection under SDKs (rmcp, tower-mcp, rust-mcp-sdk, pmcp), but `## Servers` only has Typescript/Python/Go subsections. Several Rust-built MCP servers exist now — adding the section gives them a home.

**Muvon/octocode summary:**
- Semantic code indexer with GraphRAG knowledge graph + MCP server, written in Rust
- 4 MCP tools: `semantic_search`, `structural_search` (ast-grep), `view_signatures`, `graphrag`
- Tree-sitter AST parsing across 13+ languages, LanceDB vector storage
- 335+ stars • Apache 2.0 • Local-first
- Repo: https://github.com/Muvon/octocode
