### PR TITLE
Add Magertron MCP Orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Core SDKs maintained by the MCP organization:
 
 ### Community
 - [Langchain](https://github.com/rectalogic/langchain-mcp) - Support for LangChain.
+- [MCP Orchestrator](https://github.com/curtismager20/magertron-mcpm) - Kubernetes-native MCP control plane. Deploy MCP servers as pods in your own cluster, govern access with policy, audit every action. One Helm chart, Apache 2.0, free up to 20 servers.
 - [MCP Installer](https://github.com/anaisbetts/mcp-installer) - A server that installs other MCP servers for you.
 - [MCP get](https://github.com/michaellatman/mcp-get) - A command-line tool for installing and managing Model Context Protocol (MCP) servers.
 - [Fast MCP](https://github.com/jlowin/fastmcp) - Create tools, expose resources, and define prompts with clean Pythonic code.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ Core SDKs maintained by the MCP organization:
 
 ### Community
 - [Langchain](https://github.com/rectalogic/langchain-mcp) - Support for LangChain.
-- [MCP Orchestrator](https://github.com/curtismager20/magertron-mcpm) - Kubernetes-native MCP control plane. Deploy MCP servers as pods in your own cluster, govern access with policy, audit every action. One Helm chart, Apache 2.0, free up to 20 servers.
 - [MCP Installer](https://github.com/anaisbetts/mcp-installer) - A server that installs other MCP servers for you.
 - [MCP get](https://github.com/michaellatman/mcp-get) - A command-line tool for installing and managing Model Context Protocol (MCP) servers.
 - [Fast MCP](https://github.com/jlowin/fastmcp) - Create tools, expose resources, and define prompts with clean Pythonic code.
@@ -135,3 +134,4 @@ Core SDKs maintained by the MCP organization:
 - [Dify plugin](https://github.com/hjlarry/dify-plugin-mcp_server) - Change a Dify app to a mcp server.
 - [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 - [mcp-harness](https://github.com/gabry-ts/mcp-harness) - In-memory test harness for MCP servers in TypeScript — supertest for MCP.
+- [MCP Orchestrator](https://github.com/curtismager20/magertron-mcpm) - Kubernetes-native MCP control plane. Deploy MCP servers as pods in your own cluster, govern access with policy, audit every action.


### PR DESCRIPTION
**Why it fits this list:** Magertron isn't an MCP server itself — it's infrastructure that *runs and governs* MCP servers at scale. Operators deploy MCP servers from any container image as Kubernetes pods, route traffic through an Envoy xDS-powered gateway, and enforce policy at the gRPC ext_authz layer. Designed for teams that need to bring MCP under enterprise infrastructure controls (RBAC, SSO, audit trails, SIEM integration).

**Highlights:**
- One Helm chart, Apache 2.0
- OSS free up to 20 servers — no signup, no credit card
- Multi-node high availability (pod anti-affinity, topology spread, autoscaling Envoy data plane) — shipped in v2.2.0
- OCSF-aligned audit events, validated end-to-end with Splunk Cloud
- Real install path: `helm repo add magertron https://magertron.com/charts && helm install magertron magertron/orchestrator`

**Links:**
- Website: https://magertron.com
- Security & Threat Model: https://magertron.com/security.html
- SIEM Integration: https://magertron.com/siem-integration.html
- Source: https://github.com/curtismager20/magertron-mcpm
- Artifact Hub: https://artifacthub.io/packages/helm/magertron/mcp-orchestrator

Happy to adjust placement, wording, or category if there's a better fit in the list structure. Thanks for maintaining this.
