### PR TITLE
Add dakera-mcp — self-hosted Rust MCP agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Official Github](https://github.com/github/github-mcp-server) - Seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
 - [Hoofy](https://github.com/HendryAvila/Hoofy) - Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline, and greenfield project pipeline with Clarity Gate. 32 MCP tools, single binary, zero dependencies.
 
+### Rust
+
+#### Community
+- [dakera-mcp](https://github.com/dakera-ai/dakera-mcp) - Self-hosted MCP-native agent memory server. 83 tools for persistent, decay-weighted episodic memory across agent sessions. RocksDB + HNSW vector search, 87.8% LoCoMo benchmark score. Multi-SDK support (Python/JS/Rust/Go), Docker Compose deployment.
+
 ## Clients
 
 ### Community


### PR DESCRIPTION
## Add dakera-ai/dakera-mcp

**[dakera-mcp](https://github.com/dakera-ai/dakera-mcp)** is a self-hosted MCP-native agent memory server written in Rust — a natural fit for a new **Rust Servers** subsection.

### Why it belongs here
The list currently covers TypeScript, Python, and Go servers, but has no Rust server entries. dakera-mcp is a high-quality Rust MCP server with:

- **83 MCP tools** for persistent agent memory (store, recall, session, namespace, decay config)
- **Decay-weighted vector recall** — memories naturally fade over time, mimicking human memory
- **RocksDB + HNSW** — production-grade backend for persistence and vector search
- **87.8% LoCoMo benchmark** — a standardized long-term conversational memory evaluation
- **Multi-SDK** (Python/JS/Rust/Go) + Docker Compose deployment
- **Apache-2.0 licensed**, fully self-hosted

Adds a new  subsection under  with dakera-mcp as the first community entry.