### PR TITLE
Add click-to-mcp to Community Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Core SDKs maintained by the MCP organization:
 - [Dify plugin](https://github.com/hjlarry/dify-plugin-mcp_server) - Change a Dify app to a mcp server.
 - [mcpbr](https://github.com/greynewell/mcpbr) - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 - [mcp-harness](https://github.com/gabry-ts/mcp-harness) - In-memory test harness for MCP servers in TypeScript — supertest for MCP.
+- [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) - Auto-wrap any Click/typer CLI as an MCP server. Introspects CLI commands at runtime, maps them to MCP tools.


### PR DESCRIPTION
Add [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the Tools > Community section.

click-to-mcp auto-wraps any Click/typer CLI as an MCP server — it introspects CLI commands and options at runtime and maps them to MCP tools. Supports stdio and HTTP+SSE transport.

This is a developer tool that makes it easy to convert existing CLIs into MCP servers, fitting naturally in the Tools category.