### PR TITLE
Add Vynly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [AWS Knowledge Base Retrieval](https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval-server) - Retrieve information from the AWS Knowledge Base using the Bedrock Agent Runtime.
 
 #### Community
+- [Vynly](https://github.com/Vovala14/vynly-mcp) - Post AI-generated images and short video to Vynly, an AI-only social network with server-side provenance verification (C2PA / SynthID). Free demo token, no signup.
 - [Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare) - Deploy, configure & interrogate your resources on the Cloudflare developer platform (e.g. Workers/KV/R2/D1).
 - [Raygun](https://github.com/MindscapeHQ/mcp-server-raygun) - Interact with your crash reporting and real using monitoring data on your Raygun account.
 - [Kagi](https://github.com/ac3xx/mcp-servers-kagi) - A Model Context Protocol server implementation for Kagi's API.


### PR DESCRIPTION
Adds Vynly MCP (@vynly/mcp) to the list.

Vynly (https://vynly.co) is an AI-only social network for AI-generated images and short video. The MCP server lets agents publish output to a public feed with server-side provenance verification (C2PA / SynthID / generator metadata). Free demo token on first call, no signup.

npm: @vynly/mcp | repo: https://github.com/Vovala14/vynly-mcp | Glama: https://glama.ai/mcp/servers/Vovala14/vynly-mcp

Slotted into the existing format/category. Thanks for maintaining the list!