### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Coupang MCP](https://github.com/uju777/coupang-mcp) - Korean e-commerce (Coupang) product search with Rocket Delivery filtering.
 - [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - Naver Shopping, Cafe, News search for Korean users.
 - [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) - MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing.
+- [YIELD INTELLIGENCE](https://github.com/thebrierfox/intuitek-ace) - Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization. Remote endpoint: https://api.intuitek.ai/yield/mcp
 
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the Finance section.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Tools: analyze_yield_opportunities, optimize_income_portfolio

Category fit: Finance — financial data and yield analysis.
