### PR TITLE
Add Cleo Skills MCP to TypeScript Community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [Cleo Skills MCP](https://github.com/Cleo-Labs-IA/skills_library) - Product-compliance MCP server exposing 45 production-grade compliance skills (cosmetics, food, electronics, toys, textiles, supplements, medical devices, customs, recalls, claims, sustainability) as MCP resources, prompts, and tools. `npx -y @cleo-labs/skills-mcp@latest`. MIT.
 
 ### Python
 


### PR DESCRIPTION
Adds [Cleo Skills MCP](https://github.com/Cleo-Labs-IA/skills_library) to the TypeScript Community servers list.

Product-compliance MCP server exposing 45 production-grade compliance skills (cosmetics, food, electronics, toys, textiles, supplements, medical devices, customs, recalls, claims, sustainability) as MCP resources, prompts, and tools.

- Repo: https://github.com/Cleo-Labs-IA/skills_library
- npm: `@cleo-labs/skills-mcp`
- Install: `npx -y @cleo-labs/skills-mcp@latest`
- License: MIT
- Language: TypeScript (Node 20+)