### PR TITLE
Add TWZRD Agent Intel - Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Coupang MCP](https://github.com/uju777/coupang-mcp) - Korean e-commerce (Coupang) product search with Rocket Delivery filtering.
 - [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - Naver Shopping, Cafe, News search for Korean users.
 - [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) - MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing.
+- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) - Solana-native agent trust scoring via x402 micropayments. Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. Remote server at intel.twzrd.xyz/mcp (Streamable-HTTP, no install needed).
 
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Coupang MCP](https://github.com/uju777/coupang-mcp) - Korean e-commerce (Coupang) product search with Rocket Delivery filtering.
 - [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) - Naver Shopping, Cafe, News search for Korean users.
 - [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) - MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing.
-- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) - Solana-native agent trust scoring via x402 micropayments. Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. Remote server at intel.twzrd.xyz/mcp (Streamable-HTTP, no install needed).
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana-native agent trust scoring via x402 micropayments. Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. Remote server at intel.twzrd.xyz/mcp (Streamable-HTTP, no install needed).
 
 ### Go
 - [Filesystem](https://github.com/mark3labs/mcp-filesystem-server) - File operations with configurable access controls.


### PR DESCRIPTION
Adds TWZRD Agent Intel: a remote MCP server providing Solana agent trust scoring and x402 micropayment verification. Free on-chain preflight checks + paid signed V5 trust receipts at intel.twzrd.xyz.

**Server details:**
- **Name**: TWZRD Agent Intel
- **URL**: https://intel.twzrd.xyz
- **Live endpoint**: https://intel.twzrd.xyz/mcp (Streamable-HTTP transport, no install needed)
- **Language**: Python
- **Description**: Solana-native agent trust scoring via x402 micropayments — free on-chain preflight checks (agent score, wallet validation, activity scan) + paid signed V5 trust receipts settled in <1s on Solana

Added in the Python > Community section alongside other blockchain/web3 servers.