### PR TITLE
Add ProposalCraft — MCP server for freelance proposal drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All current MCP servers are not in one language. Here is a list from official re
 - [Agentic Ads](https://github.com/nicofains1/agentic-ads) - Affiliate marketing MCP server for contextual product recommendations with USDC commission payouts.
 - [newsmcp](https://github.com/pranciskus/newsmcp) - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [preflight](https://github.com/preflight-dev/preflight) - 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts.
+- [ProposalCraft](https://github.com/jabbawocky/proposalcraft) - Draft client proposals in your voice using your past winning proposals as style examples. Paste a brief, get a ready-to-send proposal. Includes analyze_brief, draft_proposal tools and 12 industry templates. Zero API key, fully local.
 
 ### Python
 


### PR DESCRIPTION
## What

Adds [ProposalCraft](https://github.com/jabbawocky/proposalcraft) to the TypeScript Community servers section.

## Why

ProposalCraft is an MCP server for freelancers that drafts client proposals in the user's own voice by learning from their past winning proposals. Key features:
- `analyze_brief` and `draft_proposal` tools
- 12 bundled industry templates (design, development, consulting, etc.)
- Zero API key required — fully local, no data sent externally
- Install via `npx -y github:jabbawocky/proposalcraft`

Fits the TypeScript Community section.