### PR TITLE
Add wopee-mcp to Dev, Code & Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
 ## Contents
 
 - [Servers](#servers)
-  - [Dev, Code & Git](#dev-code--git) (14)
+  - [Dev, Code & Git](#dev-code--git) (15)
   - [Databases & Data](#databases--data) (2)
   - [Cloud, DevOps & Monitoring](#cloud-devops--monitoring) (6)
   - [Web, Search & Browser](#web-search--browser) (10)
@@ -60,6 +60,7 @@ Standout community servers by traction and activity.
 | [Hoofy](https://github.com/HendryAvila/Hoofy) | Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline, and greenfield project pipeline with Clarity Gate. 32 MCP tools, single binary, zero dependencies. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/go/go-original.svg" width="18" alt="Go" title="Go"> | 🟢 2mo | 14 |
 | [preflight](https://github.com/preflight-dev/preflight) | 24-tool MCP server for Claude Code that scores prompts before execution, catches ambiguity, tracks correction patterns, and estimates token cost — reduces wasted tokens from vague prompts. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 2mo | 8 |
 | [Filesystem](https://github.com/philgei/mcp_server_filesystem) | File operations with configurable access controls. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🔴 1y | 5 |
+| [wopee-mcp](https://github.com/Wopee-io/wopee-mcp) | Autonomous AI testing for web apps — generate test cases and user stories, dispatch test, analysis and AI-agent runs, and fetch artifacts and project status via Wopee.io. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 4w | 3 |
 | [Phabricator](https://github.com/baba786/phabricator-mcp-server) | Interact with Phabricator API. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | ❌ gone | — |
 
 ### Databases & Data


### PR DESCRIPTION
Re-submission of #46 with a public GitHub link, as you suggested when closing it.

#46 was closed because the entry linked to npm while the source was private. The source is now **public and MIT-licensed**: https://github.com/Wopee-io/wopee-mcp — it's also what the npm `wopee-mcp` package's `repository` field points to.

Since the list has moved to the category-table format, I've added a fresh row under **Dev, Code & Git** rather than reopening the old diff:

- **Repo:** https://github.com/Wopee-io/wopee-mcp (MIT, TypeScript)
- **Install:** `npx wopee-mcp`
- **What it does:** connects Claude, Cursor, or any MCP client to Wopee.io to generate test cases and user stories, dispatch test / analysis / AI-agent runs, and fetch artifacts and project status.

Placed near the bottom of the section to match the star-descending order, and bumped the section count to (15). Happy to adjust the wording, category, or placement.