### PR TITLE
feat: add The Stall — 198-capability x402 finance & data MCP server (v4.52.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
   - [Commerce, Ads & Business](#commerce-ads--business) (9)
   - [AI, Agents & Memory](#ai-agents--memory) (5)
   - [Media & 3D](#media--3d) (3)
-  - [Finance & Crypto](#finance--crypto) (1)
+  - [Finance & Crypto](#finance--crypto) (2)
   - [Other](#other) (7)
 - [Clients](#clients)
 - [SDKs](#sdks)
@@ -149,6 +149,7 @@ Standout community servers by traction and activity.
 | Server | Description | Lang | Activity | ⭐ |
 |---|---|---|:--:|--:|
 | [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) | MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 1d | 94 |
+| [The Stall](https://github.com/thebrierfox/the-stall) | 183-capability MCP server for financial markets, crypto, and on-chain data. Covers equities, ETFs, hedge fund holdings, options, insider trades, Treasury yields, and Base chain analytics. Pay-per-call with x402 micropayments. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | 🟢 0d | 0 |
 
 ### Other
 


### PR DESCRIPTION
## Summary

Adds [The Stall](https://github.com/thebrierfox/the-stall) to the **Finance & Crypto** section.

### What it is

The Stall is a 198-capability MCP server covering financial markets, crypto, and on-chain data:

- **Equities**: real-time quotes, analyst ratings, insider trades, earnings surprises, equity fundamentals, income statements
- **ETFs & funds**: holdings, flows, hedge fund 13F positions
- **Options**: full chain, IV, Greeks via CBOE; short volume intel, equity technicals
- **Macro**: Treasury yields, Federal Reserve data, commodity futures, forex, FOMC tracker
- **DeFi & crypto**: DEX quotes, whale radar, on-chain wallet analysis, stablecoin watch, funding rates
- **Compliance**: sanctions screening, address security, EVM token security, wallet credit score
- **Data & Intel**: congressional trades, SEC filings, global news intel (200+ languages), Reddit intel, wayback intel

### How it works

No accounts, no API keys. Connect via MCP, call any tool, pay per call in USDC on Base mainnet via x402.

**MCP endpoint:** `https://the-stall.intuitek.ai/mcp`  
**Version:** v4.52.0 | 198 capabilities  
**GitHub:** https://github.com/thebrierfox/the-stall
