### PR TITLE
Add AccInt to AI, Agents & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Standout community servers by traction and activity.
 | [OpenAI](https://github.com/pierrebrunelle/mcp-server-openai) | Query OpenAI models directly from Claude. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🔴 1y | 81 |
 | [WritBase](https://github.com/Writbase/writbase) | MCP-native task management for AI agent fleets with multi-agent permissions, delegation safety, and full provenance. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 2mo | 6 |
 | [Nucleus MCP](https://github.com/eidetic-works/nucleus-mcp) | 114 MCP tools for persistent memory, execution verification, governance, and compliance. Local-first. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 4w | 2 |
+| [AccInt](https://github.com/maxbaluev/accreted-intelligence) | Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. Shares a SQLite substrate and feeds verified outcomes back into future retrieval. | — | 🟢 0d | 1 |
 | [PraisonAI](https://github.com/MervinPraison/praisonai-mcp) | AI Agents framework with 64+ built-in MCP tools for search, memory, workflows, code execution, and file operations. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟡 4mo | 1 |
 
 ### Media & 3D


### PR DESCRIPTION
Adds AccInt to the `AI, Agents & Memory` server table.

AccInt fits this section as a local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. It shares a SQLite-backed substrate and feeds verified outcomes back into future retrieval.

Notes on metadata:
- Activity/stars were taken from live GitHub repo metadata at submission time (`0d`, `1`).
- I used `—` for language because the public repo reports HTML as its primary GitHub language, while the engine is distributed as a binary; using an HTML icon would be misleading.
- The public repo contains installer/docs/host integration glue; the core engine is currently a private binary.

Validation:
- git diff --check
- New GitHub repo link returns HTTP 200