### PR TITLE
Add Public Grants MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Standout community servers by traction and activity.
 | Server | Description | Lang | Activity | ⭐ |
 |---|---|---|:--:|--:|
 | [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) | MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 1d | 94 |
+| [Public Grants](https://grants.mrchief.ai) | French public grants advisor for startups and AI agents. 21 tools for company onboarding (SIRENE registry pre-fill, auto-enrichment + customisable input), eligibility check across 49 programmes (CIR, JEI, BPI, CNC, ADEME, EIC Accelerator) with per-rule pass/fail from official legal texts, application drafting (.md/.docx export), and free strategic briefing PDF. EUR 49/dossier vs EUR 2,000-5,000 at consulting firms. Remote Streamable HTTP at `grants.mrchief.ai/mcp/`. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 | - |
 
 ### Other
 


### PR DESCRIPTION
Adds Public Grants to the Finance & Crypto section.

Public Grants is a remote MCP server that helps French startups find and apply for public funding. It replaces EUR 2,000-5,000 grant consultants with 21 MCP tools at EUR 49/dossier, free discovery included.

- Endpoint: https://grants.mrchief.ai/mcp/ (Streamable HTTP, no auth for discovery)
- 21 tools + 3 guided prompts covering onboarding, discovery (49 programmes with eligibility rules from official legal texts), drafting (.md/.docx), and strategic briefing (free PDF)
- Written in Python (FastMCP), EU-hosted (Fly.io Paris + Supabase Frankfurt), RGPD compliant
- Source code on GitLab (private repo) - hence no stars count or activity badge
- Built by [PyratzLabs](https://pyratzlabs.com)

Happy to adjust the description or move to a different section.