### PR TITLE
Add StandupCraft — MCP server for developer standups & client reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
 ## Contents
 
 - [Servers](#servers)
-  - [Dev, Code & Git](#dev-code--git) (15)
+  - [Dev, Code & Git](#dev-code--git) (16)
   - [Databases & Data](#databases--data) (2)
   - [Cloud, DevOps & Monitoring](#cloud-devops--monitoring) (6)
   - [Web, Search & Browser](#web-search--browser) (10)
@@ -62,6 +62,7 @@ Standout community servers by traction and activity.
 | [Filesystem](https://github.com/philgei/mcp_server_filesystem) | File operations with configurable access controls. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🔴 1y | 5 |
 | [wopee-mcp](https://github.com/Wopee-io/wopee-mcp) | Autonomous AI testing for web apps — generate test cases and user stories, dispatch test, analysis and AI-agent runs, and fetch artifacts and project status via Wopee.io. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 4w | 3 |
 | [Phabricator](https://github.com/baba786/phabricator-mcp-server) | Interact with Phabricator API. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | ❌ gone | — |
+| [StandupCraft](https://github.com/jabbawocky/standupcraft) | MCP server that reads git commits and GitHub activity to generate daily standups, weekly client reports, and sprint retros — inside Claude Desktop. No API key, fully local. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 1d | 0 |
 
 ### Databases & Data
 


### PR DESCRIPTION
## StandupCraft

**Repo:** https://github.com/jabbawocky/standupcraft  
**Category:** Dev, Code & Git  
**Install:** `npx -y github:jabbawocky/standupcraft`

**What it does:** MCP server that reads git commits and GitHub activity to generate daily standups, weekly client reports, and sprint retros — inside Claude Desktop. Stop reconstructing what you did from memory.

**Checklist:**
- [x] MIT license
- [x] TypeScript
- [x] No API key required, fully local
- [x] Works with Claude Desktop, Claude Code, Cursor, Windsurf
- [x] Active development