### PR TITLE
feat: add EGC - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Standout community servers by traction and activity.
 | [Nucleus MCP](https://github.com/eidetic-works/nucleus-mcp) | 114 MCP tools for persistent memory, execution verification, governance, and compliance. Local-first. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 4w | 2 |
 | [PraisonAI](https://github.com/MervinPraison/praisonai-mcp) | AI Agents framework with 64+ built-in MCP tools for search, memory, workflows, code execution, and file operations. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟡 4mo | 1 |
 
+| [EGC](https://github.com/Fmarzochi/EGC) | Persistent cross-session memory MCP server for 13+ AI coding tools. SQLite-backed state survives context resets and keeps Claude Code, Cursor, Gemini CLI, Codex, and more in sync. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | 🟢 0d | 20 |
+
 ### Media & 3D
 
 | Server | Description | Lang | Activity | ⭐ |


### PR DESCRIPTION
## Summary

- Adds [EGC](https://github.com/Fmarzochi/EGC) to the AI, Agents & Memory section
- EGC is a persistent cross-session memory MCP server for 13+ AI coding tools
- SQLite-backed state survives context resets and keeps Claude Code, Cursor, Gemini CLI, Codex, and others in sync
- MIT license, install: `npm install -g @egchq/egc`