### PR TITLE
Add DomScan to Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Standout community servers by traction and activity.
 | [Make](https://github.com/integromat/make-mcp-server) | Turn Make scenarios into callable tools for AI assistants. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 0d | 161 |
 | [domain-mcp](https://github.com/joachimBrindeau/domain-mcp) | MCP server to search, register, and manage domains (availability, DNS, WHOIS) via Dynadot API. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 7w | 9 |
 | [SheetsData](https://github.com/octoco-ltd/sheetsdata-mcp) | Instant access to electronic component datasheets for AI agents — specs, pinouts, package info, absolute max ratings extracted from manufacturer PDFs on demand. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | 🟢 6w | 7 |
+| [DomScan](https://github.com/estevecastells/domscan-mcp) | Domain intelligence covering availability, DNS, WHOIS/RDAP, SSL, subdomains, valuation, email security, and typosquatting/brand protection. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 0d | 0 |
 
 ## Clients
 


### PR DESCRIPTION
Adds [DomScan](https://github.com/estevecastells/domscan-mcp), an MCP server for domain intelligence (availability, DNS, WHOIS/RDAP, SSL, subdomains, valuation, email security, typosquatting/brand protection). Placed in Other alongside the existing domain-mcp entry, last row with placeholder Activity/star values per CONTRIBUTING; one entry per PR.