### PR TITLE
Add MAQAMI Travel - Hotel & Flight Booking MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
 - [Clients](#clients)
 - [SDKs](#sdks)
 - [Tools](#tools)
+- [MAQAMI Travel](https://github.com/negm17111995/mcp-server) - Hotel and flight booking MCP server with direct booking links for 249 countries.
 
 ## ⭐ Featured
 


### PR DESCRIPTION
Adding MAQAMI Travel to the list of MCP servers. It provides direct AI hotel and flight bookings across 249 countries.

Server: https://mcp.maqami.co
Repo: https://github.com/negm17111995/mcp-server