### PR TITLE
Add Off Grid AI Desktop to Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Standout community servers by traction and activity.
 |---|---|---|:--:|--:|
 | [n8n](https://github.com/nerding-io/n8n-nodes-mcp) | interact with Model Context Protocol (MCP) servers in your n8n workflows. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟡 5mo | 3k |
 | [eechat](https://github.com/Lucassssss/eechat) | An open-source, cross-platform desktop application that seamlessly connects with full support for MCP, across Linux, macOS, and Windows. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | 🟡 11mo | 343 |
+| [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop) | Local-first macOS app that runs a full AI suite on-device (LLM chat, image generation, transcription, memory/RAG) and connects to MCP servers as a client, with no account or telemetry. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 0d | 0 |
 
 ## SDKs
 


### PR DESCRIPTION
Adds Off Grid AI Desktop to the Clients section. It is an open-source (AGPL-3.0) macOS Electron app that runs a full AI suite on-device (local LLM chat, image generation, transcription, memory/RAG) and acts as an MCP client that connects to MCP servers, with no account or telemetry.

Disclosure: I'm involved with the project.