### PR TITLE
Add Nika (read-only workflow oracle) to Dev, Code & Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Standout community servers by traction and activity.
 | [Filesystem](https://github.com/philgei/mcp_server_filesystem) | File operations with configurable access controls. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🔴 1y | 5 |
 | [wopee-mcp](https://github.com/Wopee-io/wopee-mcp) | Autonomous AI testing for web apps — generate test cases and user stories, dispatch test, analysis and AI-agent runs, and fetch artifacts and project status via Wopee.io. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 0d | 3 |
 | [Phabricator](https://github.com/baba786/phabricator-mcp-server) | Interact with Phabricator API. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | ❌ gone | — |
+| [Nika](https://github.com/supernovae-st/nika) | Read-only workflow oracle: validate `.nika.yaml` DAGs, explain findings, honest cost estimate — before a single token is spent. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rust/rust-original.svg" width="18" alt="Rust" title="Rust"> | 🟢 0d | 0.1k |
 
 ### Databases & Data
 


### PR DESCRIPTION
Adds the **nika** read-only MCP oracle (house format).

`nika mcp` exposes the Nika workflow engine's oracle over stdio: agents validate `.nika.yaml` workflow DAGs, get findings explained with fix guidance, browse schema/examples, and see an honest cost estimate — all **before a single token is spent**. No execution and no mutation over MCP by design (threat model documented in-repo). Binary install: `brew install supernovae-st/tap/nika` or SHA256SUMS-verified release tarballs.

Disclosure: I'm the author.
