### PR TITLE
Add AgentServices — x402-paid crypto data APIs (Finance & Crypto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
   - [Commerce, Ads & Business](#commerce-ads--business) (10)
   - [AI, Agents & Memory](#ai-agents--memory) (6)
   - [Media & 3D](#media--3d) (4)
-  - [Finance & Crypto](#finance--crypto) (1)
+  - [Finance & Crypto](#finance--crypto) (2)
   - [Other](#other) (7)
 - [Clients](#clients)
 - [SDKs](#sdks)
@@ -154,6 +154,7 @@ Standout community servers by traction and activity.
 | Server | Description | Lang | Activity | ⭐ |
 |---|---|---|:--:|--:|
 | [RustChain MCP](https://github.com/Scottcjn/rustchain-mcp) | MCP server for the RustChain blockchain and BoTTube video platform. AI agent tools for mining, wallet management, bounty hunting, and video publishing. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 0d | 97 |
+| [AgentServices](https://agentservices.to) | x402-paid data APIs for AI agents — 54 services, 37 MCP tools, crypto market data, financial data, and onchain analytics with native payment protocol. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 0d | 3 |
 
 ### Other
 


### PR DESCRIPTION
## What

Adds [AgentServices](https://agentservices.to) to the **Finance & Crypto** section.

## About AgentServices

AgentServices is a production x402-paid data API platform for AI agents:
- **54 services** across crypto market data, financial data, and onchain analytics
- **37 MCP tools** exposed via `https://api.agentservices.to/mcp`
- **41 x402-paid endpoints** using the HTTP 402 Payment Required protocol
- Native MCP support (protocol 2026-07-28, server v5.3.0)
- Listed on the official MCP Registry: `to.agentservices/agentservices`

## Format

Entry follows the existing table format (Server, Description, Lang, Activity, ⭐). Python is the primary language.

Happy to adjust formatting if needed.