### PR TITLE
Add Autoposting MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
   - [Cloud, DevOps & Monitoring](#cloud-devops--monitoring) (6)
   - [Web, Search & Browser](#web-search--browser) (12)
   - [Productivity, Docs & Knowledge](#productivity-docs--knowledge) (4)
-  - [Communication & Social](#communication--social) (4)
+  - [Communication & Social](#communication--social) (5)
   - [Commerce, Ads & Business](#commerce-ads--business) (10)
   - [AI, Agents & Memory](#ai-agents--memory) (6)
   - [Media & 3D](#media--3d) (4)
@@ -116,6 +116,7 @@ Standout community servers by traction and activity.
 | [WhatsApp](https://github.com/lharries/whatsapp-mcp) | Search your personal Whatsapp messages, search your contacts and send messages to either individuals or groups. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/go/go-original.svg" width="18" alt="Go" title="Go"> | 🔴 1y | 6.1k |
 | [posteverywhere/mcp](https://github.com/posteverywhere/mcp) | Schedule and publish to Instagram, TikTok, YouTube, LinkedIn, Facebook, X, Threads, Pinterest, Bluesky, Discord, and Telegram from natural language. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 10d | 2 |
 | [SocialRouter](https://github.com/socialrouter/mcp) | Unified API to fetch social media data across LinkedIn, Instagram, X, Reddit, TikTok, YouTube, and more, with automatic provider failover. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 3d | 0 |
+| [Autoposting](https://github.com/Autoposting-ai/autoposting-mcp) | Remote MCP server that drafts, rewrites, schedules and publishes social posts to X, LinkedIn, Instagram, Threads and YouTube, with AI idea generation, carousels, video clipping and knowledge-base search. | — | 🟢 0d | 0 |
 
 ### Commerce, Ads & Business
 


### PR DESCRIPTION
Adds Autoposting to Servers › Communication & Social (Contents count bumped 4 → 5).

Autoposting is a hosted MCP server that drafts and rewrites posts, generates ideas with AI agents, builds carousels, clips and renders video, searches a knowledge base, and schedules or publishes to X, LinkedIn, Instagram, Threads and YouTube — 69 tools in total.

- Endpoint: `https://app.autoposting.ai/mcp`, Streamable HTTP with OAuth 2.1 Dynamic Client Registration, so there is no client id/secret to configure and nothing to install locally.
- Docs: https://docs.autoposting.ai/mcp/overview
- Published in the official MCP registry as `ai.autoposting/autoposting`.
