### PR TITLE
Add sms-florin-mcp to Communication & Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
   - [Cloud, DevOps & Monitoring](#cloud-devops--monitoring) (6)
   - [Web, Search & Browser](#web-search--browser) (12)
   - [Productivity, Docs & Knowledge](#productivity-docs--knowledge) (4)
-  - [Communication & Social](#communication--social) (4)
+  - [Communication & Social](#communication--social) (5)
   - [Commerce, Ads & Business](#commerce-ads--business) (10)
   - [AI, Agents & Memory](#ai-agents--memory) (6)
   - [Media & 3D](#media--3d) (4)
@@ -116,6 +116,7 @@ Standout community servers by traction and activity.
 | [WhatsApp](https://github.com/lharries/whatsapp-mcp) | Search your personal Whatsapp messages, search your contacts and send messages to either individuals or groups. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/go/go-original.svg" width="18" alt="Go" title="Go"> | 🔴 1y | 6.1k |
 | [posteverywhere/mcp](https://github.com/posteverywhere/mcp) | Schedule and publish to Instagram, TikTok, YouTube, LinkedIn, Facebook, X, Threads, Pinterest, Bluesky, Discord, and Telegram from natural language. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 10d | 2 |
 | [SocialRouter](https://github.com/socialrouter/mcp) | Unified API to fetch social media data across LinkedIn, Instagram, X, Reddit, TikTok, YouTube, and more, with automatic provider failover. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 3d | 0 |
+| [sms-florin-mcp](https://github.com/flovoice53-tech/sms-florin-mcp) | Rents a real UK phone number (physical SIM, not VoIP) and receives SMS/OTP codes, so an AI agent can complete signup/verification flows during testing without a personal number. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 0d | 0 |
 
 ### Commerce, Ads & Business
 


### PR DESCRIPTION
Adds `sms-florin-mcp` — an MCP server that lets AI coding agents (Claude Code, Cursor, etc.) rent a real UK phone number and receive SMS/OTP codes mid-task, for testing signup/verification flows (WhatsApp, Telegram, Discord, Google, etc.) without burning a personal number.

- The MCP server *is* the whole product of this repo (no separate app it's bolted onto) — 4 tools (`list_services`, `rent_number`, `get_rental`, `wait_for_sms`) wrapping a REST API for exactly this purpose.
- Real phone numbers on physical UK SIM cards (EE/Three), not a VoIP/virtual number reseller.
- Published on npm (`sms-florin-mcp`), MIT licensed, listed on the official MCP Registry, Docker MCP Registry, and Glama.
- Repo: https://github.com/flovoice53-tech/sms-florin-mcp

Placed under Communication & Social next to the existing WhatsApp/SocialRouter entries. Left Lang/Activity/⭐ as placeholders per CONTRIBUTING.md.