### PR TITLE
Add Skillselion to AI, Agents & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
   - [Productivity, Docs & Knowledge](#productivity-docs--knowledge) (4)
   - [Communication & Social](#communication--social) (5)
   - [Commerce, Ads & Business](#commerce-ads--business) (10)
-  - [AI, Agents & Memory](#ai-agents--memory) (6)
+  - [AI, Agents & Memory](#ai-agents--memory) (7)
   - [Media & 3D](#media--3d) (4)
   - [Finance & Crypto](#finance--crypto) (1)
   - [Other](#other) (7)
@@ -143,6 +143,7 @@ Standout community servers by traction and activity.
 | [WritBase](https://github.com/Writbase/writbase) | MCP-native task management for AI agent fleets with multi-agent permissions, delegation safety, and full provenance. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟡 4mo | 8 |
 | [Nucleus MCP](https://github.com/eidetic-works/nucleus-mcp) | 114 MCP tools for persistent memory, execution verification, governance, and compliance. Local-first. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 1d | 4 |
 | [PraisonAI](https://github.com/MervinPraison/praisonai-mcp) | AI Agents framework with 64+ built-in MCP tools for search, memory, workflows, code execution, and file operations. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟡 6mo | 1 |
+| [Skillselion](https://github.com/skillselion/skillselion-mcp) | Loads community agent skills on demand, materializing a matching SKILL.md and its bundled files into the session, and can merge the top matches into one provenance-tagged digest. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | 🟢 0d | 0 |
 
 ### Media & 3D
 


### PR DESCRIPTION
Adds one row to **Servers › AI, Agents & Memory** and bumps that category's count in Contents (6 → 7).

**Is it really an MCP server?** Yes — the repo is the MCP server and nothing else. Remove the server and the project has no purpose. The catalog it queries is a separate product with its own repo; this package is a ~30 KB stdio server published to npm.

- Repo: https://github.com/skillselion/skillselion-mcp (MIT, JavaScript)
- Install: `npx -y skillselion-mcp` — stdio, read-only, no auth or API key
- Tools (4): `load_skill`, `synthesize_skills`, `search_skillselion`, `top_skillselion`
- MCP Registry id: `io.github.skillselion/skillselion-mcp` (ACTIVE)

Placeholders `🟢 0d` / `0` used for Activity and stars per CONTRIBUTING; row appended as the last line of its section for automatic re-sorting. Not added to Featured.