### PR TITLE
Add open-mcp-apps to Productivity, Docs & Knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
   - [Databases & Data](#databases--data) (2)
   - [Cloud, DevOps & Monitoring](#cloud-devops--monitoring) (6)
   - [Web, Search & Browser](#web-search--browser) (12)
-  - [Productivity, Docs & Knowledge](#productivity-docs--knowledge) (4)
+  - [Productivity, Docs & Knowledge](#productivity-docs--knowledge) (5)
   - [Communication & Social](#communication--social) (5)
   - [Commerce, Ads & Business](#commerce-ads--business) (10)
   - [AI, Agents & Memory](#ai-agents--memory) (7)
@@ -107,6 +107,7 @@ Standout community servers by traction and activity.
 | [Google Drive](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive) ✅ | File access and search capabilities for Google Drive. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 0d | 89.2k |
 | [Obsidian](https://github.com/MarkusPfundstein/mcp-obsidian) | Interact with Obsidian. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟢 2mo | 4.2k |
 | [Taskade MCP](https://github.com/taskade/mcp) ✅ | Official Taskade MCP server with 50+ tools for managing workspaces, projects, tasks, custom AI agents, knowledge bases, and workflow automations. Includes OpenAPI-to-MCP codegen. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 5d | 161 |
+| [open-mcp-apps](https://github.com/2nd1st/open-mcp-apps) | MCP Apps engine where the AI builds interactive UI apps — todo boards, habit trackers, dashboards — that persist across conversations, backed by data collections. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | 🟢 0d | 0 |
 
 ### Communication & Social
 


### PR DESCRIPTION
Adds one row to **Servers › Productivity, Docs & Knowledge**, appended as the last line of the section per CONTRIBUTING, and bumps the Contents count 4 → 5.

**What it is:** an MCP Apps engine. The AI builds an interactive UI app once — a todo board, a habit tracker, a dashboard — and it persists, backed by data collections that outlive the conversation. Renders in Claude, ChatGPT, Codex, or any MCP Apps host. AGPL-3.0 engine, MIT apps.

On the "is it really an MCP server?" test: remove the MCP server and nothing is left — the whole project *is* the server (33 tools, local stdio).

Install: `curl -fsSL https://raw.githubusercontent.com/2nd1st/open-mcp-apps/main/install.sh | sh`
(Note: the `open-mcp-apps` name on npm is an unrelated package — install from the repo.)

Not previously listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)