### PR TITLE
Add APITube News MCP to Web, Search & Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
   - [Dev, Code & Git](#dev-code--git) (15)
   - [Databases & Data](#databases--data) (2)
   - [Cloud, DevOps & Monitoring](#cloud-devops--monitoring) (6)
-  - [Web, Search & Browser](#web-search--browser) (12)
+  - [Web, Search & Browser](#web-search--browser) (13)
   - [Productivity, Docs & Knowledge](#productivity-docs--knowledge) (5)
   - [Communication & Social](#communication--social) (5)
   - [Commerce, Ads & Business](#commerce-ads--business) (10)
@@ -98,6 +98,7 @@ Standout community servers by traction and activity.
 | [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) | Search scientific papers and get structured experimental data from full-text studies. Remote MCP server with free tier. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | ❌ gone | — |
 | [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) | Naver Shopping, Cafe, News search for Korean users. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟡 6mo | 0 |
 | [Helium MCP](https://github.com/connerlambden/helium-mcp) | News search with per-outlet bias scores (37 dimensions, 216 sources), balanced multi-source synthesis, live equity/ETF/crypto quotes, and ML options pricing. Remote streamable HTTP, 9 tools. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | ❌ gone | — |
+| [APITube News MCP](https://github.com/apitube/news-api-mcp) | Hosted news search over the APITube News API across 500,000+ sources in 177 countries and 59 languages, with sentiment scores, named entities and IPTC categories on every article. | — | 🟢 0d | 0 |
 
 ### Productivity, Docs & Knowledge
 


### PR DESCRIPTION
Adds **APITube News MCP** to `Servers › Web, Search & Browser`.

A hosted MCP server that gives an agent structured news search — not scraped HTML — over the APITube News API.

| Property | Value |
|----------|-------|
| Repository | https://github.com/apitube/news-api-mcp (MIT) |
| Endpoint | `https://mcp.apitube.io/` |
| Transport | Streamable HTTP (`POST /`), JSON-RPC 2.0 |
| Protocol | `2025-11-25`, negotiates down (`2024-11-05` works) |
| Auth | `Authorization: Bearer <API_KEY>` or `X-API-Key` |
| Official registry | `io.apitube/news` |
| Docs | https://docs.apitube.io/platform/news-api/ai/mcp-server |

**Two tools:**

- `search_news` — keywords, language, country, source domain and quality rank, sentiment range, named entities, media, date ranges, sorting, faceting, highlighting.
- `suggest` — resolves a name like "Tesla" into the entity, category, topic and industry IDs the precise filters need.

Every article comes back with sentiment scores, extracted entities (people, organizations, locations, brands, events), IPTC categories, topics and industries.

**Verify without a key** — `tools/list` answers unauthenticated:

```bash
curl -s -X POST https://mcp.apitube.io/ \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

**Notes against CONTRIBUTING:**

- *Is it really an MCP server?* Yes — the repository exists only to ship this MCP server. Remove the MCP server and nothing is left; it is not a connector bolted onto a larger product.
- **Lang is `—` on purpose.** The repository holds the README, client configs and `server.json` for a hosted endpoint — there is no code tree to detect a language from.
- No ` ✅` marker, no Featured row, placeholder `🟢 0d` / `0`, row appended as the last line of its section, and the Contents count for *Web, Search & Browser* bumped 12 → 13.
- No duplicate: the list has no APITube entry today.
