### PR TITLE
Add StackScan to Web, Search & Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Standout community servers by traction and activity.
 | [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) | Search scientific papers and get structured experimental data from full-text studies. Remote MCP server with free tier. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | ❌ gone | — |
 | [Naver Search MCP](https://github.com/uju777/mcp-server-naver-search) | Naver Shopping, Cafe, News search for Korean users. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🟡 6mo | 0 |
 | [Helium MCP](https://github.com/connerlambden/helium-mcp) | News search with per-outlet bias scores (37 dimensions, 216 sources), balanced multi-source synthesis, live equity/ETF/crypto quotes, and ML options pricing. Remote streamable HTTP, 9 tools. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | ❌ gone | — |
+| [StackScan](https://github.com/stackscan/stackscan-mcp) | Looks up the technologies on any domain and the company behind it, and reports how many sites run a given technology and where. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="18" alt="JavaScript" title="JavaScript"> | 🟢 0d | 0 |
 
 ### Productivity, Docs & Knowledge
 


### PR DESCRIPTION
Adds StackScan to **Web, Search & Browser**.

**Disclosure: I work on StackScan.**

On the "is it really an MCP server?" test: the entry links [stackscan/stackscan-mcp](https://github.com/stackscan/stackscan-mcp), a dedicated repository whose only purpose is the MCP server. Remove the MCP server and nothing is left, so it is not a connector bolted onto another product.

Six tools over a technology index: what a domain is built on, the company behind it (industry, city, country, LinkedIn), how many sites run a given technology and where, batch domain lookup, and a free credit-balance check. MIT, published to npm as `@stackscan/mcp-server`, runs as a local stdio process.

Lang, Activity and ⭐ are placeholders per the contributing guide.
