### PR TITLE
Add GhidraLens to Dev, Code & Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Servers are grouped by what they do. Each row shows the real language, reposito
 ## Contents
 
 - [Servers](#servers)
-  - [Dev, Code & Git](#dev-code--git) (15)
+  - [Dev, Code & Git](#dev-code--git) (16)
   - [Databases & Data](#databases--data) (2)
   - [Cloud, DevOps & Monitoring](#cloud-devops--monitoring) (6)
   - [Web, Search & Browser](#web-search--browser) (12)
@@ -63,6 +63,7 @@ Standout community servers by traction and activity.
 | [Filesystem](https://github.com/philgei/mcp_server_filesystem) | File operations with configurable access controls. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | 🔴 1y | 5 |
 | [wopee-mcp](https://github.com/Wopee-io/wopee-mcp) | Autonomous AI testing for web apps — generate test cases and user stories, dispatch test, analysis and AI-agent runs, and fetch artifacts and project status via Wopee.io. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 13d | 5 |
 | [Phabricator](https://github.com/baba786/phabricator-mcp-server) | Interact with Phabricator API. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="18" alt="Python" title="Python"> | ❌ gone | — |
+| [GhidraLens](https://github.com/hellosverre/ghidralens) | Interactive Ghidra views inside the client: decompile a binary, rename symbols in the live program, and navigate the call graph. | <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="18" alt="TypeScript" title="TypeScript"> | 🟢 0d | 0 |
 
 ### Databases & Data
 


### PR DESCRIPTION
[GhidraLens](https://github.com/hellosverre/ghidralens) is an MCP server for [Ghidra](https://ghidra-sre.org/) that returns its analysis as an *interactive view* inside the client, using the MCP Apps extension (`io.modelcontextprotocol/ui`), rather than as text. Click an identifier to rename it in the live program; the model's next decompile sees the new name.

Three views — decompiler, function browser, call graph — plus a resident PyGhidra session so auto-analysis runs once rather than per request.

On the "is it really an MCP server?" test: remove the MCP server and nothing remains. The views are `ui://` resources served by it, and the Ghidra bridge exists only to feed it.

MIT, screenshots and setup in the README. Contents count for the category bumped 15 → 16.